### PR TITLE
test version of a mxml 2.10 port as a newly invented port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
-# macports-test
+# The macports-test repository
 Testing some ideas on existing ports or newly invented ports for the MacPorts project.
 
-The MacPorts Project is an open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac operating system. Apparently there are many ways one can get involved with MacPorts and peer users, system administrators & developers alike.
+The **MacPorts Project** is an open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac operating system. Apparently there are many ways one can get involved with MacPorts and peer users, system administrators & developers alike.
 
 - The MacPorts Project official homepage - https://www.macports.org
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
-Please be aware that projects included in this repository may mainly be copies from existing ports and the applicable license condition of the original project may apply as appropriate. However, this repository claims cover of the MIT Licence for all content. https://choosealicense.com/licenses/mit/
+Please be aware that projects included in this repository may mainly be copies from existing ports and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover of the MIT Licence for all content included. https://choosealicense.com/licenses/mit/
+- - - 
+# Existing ports addressed 
+## mxml
+
+## TBC
+to be continued
+
+# Newly invented ports
+(we may see)
+- - - 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please be aware that projects included in this repository may mainly be copies f
 - - - 
 # Existing ports addressed 
 ## forked-daapd
-The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports) is yet not available as a macports port and this commit is aimed at making a *forked-daapd v25.0 port* available.
+The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports) is yet not available as a macports port and I am aiming at making a *forked-daapd v25.0 port* available.
 
 ## TBC
 to be continued
@@ -23,12 +23,13 @@ The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by
 
 > The Mini-XML library is Copyright 2003-2017 by Michael R Sweet. License terms are described in the file "COPYING".
 
-Currently, mxml is not yet available as a macports port and this commit is aimed at making a *mxml port* available.
+Currently, mxml is not yet available as a macports port and I am aimed at making a *mxml port* available.
 
 Establishing a new *portfile* for mxml required two issues to be resolved through patches:
 1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201)
 2. GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html)
-The new mxml 2.10 port is a newly invented port which installs successfuly on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There should be a commitment as new official port to the MacPorts project after the testing with forked-daapd is completed.
+
+My test version of a mxml 2.10 port is a newly invented port which installs successfuly on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to become a new official port to the MacPorts project after the testing with forked-daapd is completed.
 
 ## TBC
 to be continued

--- a/README.md
+++ b/README.md
@@ -7,14 +7,29 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
-Please be aware that projects included in this repository may mainly be copies from existing ports and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover of the MIT Licence for all content included. https://choosealicense.com/licenses/mit/
+Please be aware that projects included in this repository may mainly be copies from existing ports and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover of the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
 - - - 
 # Existing ports addressed 
-## mxml
+## forked-daapd
+The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports) is yet not available as a macports port and this commit is aimed at making a *forked-daapd v25.0 port* available.
 
 ## TBC
 to be continued
 
 # Newly invented ports
-(we may see)
+## mxml
+The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports).
+> Mini-XML is a small XML parsing library that you can use to read XML data files or strings in your application without requiring large non-standard libraries. Mini-XML only requires a "make" program and an ANSI C compatible compiler - GCC works, as do most vendors' ANSI C compilers.
+
+> The Mini-XML library is Copyright 2003-2017 by Michael R Sweet. License terms are described in the file "COPYING".
+
+Currently, mxml is not yet available as a macports port and this commit is aimed at making a *mxml port* available.
+
+Establishing a new *portfile* for mxml required two issues to be resolved through patches:
+1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201)
+2. GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html)
+The new mxml 2.10 port is a newly invented port which installs successfuly on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There should be a commitment as new official port to the MacPorts project after the testing with forked-daapd is completed.
+
+## TBC
+to be continued
 - - - 

--- a/README.md
+++ b/README.md
@@ -7,29 +7,29 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
-Please be aware that projects included in this repository may mainly be copies from existing ports and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover of the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
+Please be aware that projects i.e. ports included in this repository may mainly be copies from existing ports and/or open-source projects and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover by the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
 - - - 
 # Existing ports addressed 
 ## forked-daapd
-The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports) is yet not available as a macports port and I am aiming at making a *forked-daapd v25.0 port* available.
+The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
 
 ## TBC
 to be continued
 
 # Newly invented ports
 ## mxml
-The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using macports).
+The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > Mini-XML is a small XML parsing library that you can use to read XML data files or strings in your application without requiring large non-standard libraries. Mini-XML only requires a "make" program and an ANSI C compatible compiler - GCC works, as do most vendors' ANSI C compilers.
 
 > The Mini-XML library is Copyright 2003-2017 by Michael R Sweet. License terms are described in the file "COPYING".
 
-Currently, mxml is not yet available as a macports port and I am aimed at making a *mxml port* available.
+Currently, mxml is not yet available as a MacPorts port and I am aimed at making a *mxml port* available.
 
 Establishing a new *portfile* for mxml required two issues to be resolved through patches:
 1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201)
-2. GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html)
+2. Missing GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html)
 
-My test version of a mxml 2.10 port is a newly invented port which installs successfuly on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to become a new official port to the MacPorts project after the testing with forked-daapd is completed.
+My test version of a mxml 2.10 port is a newly invented port which installs successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to become a new official port to the MacPorts project after the testing with forked-daapd is completed.
 
 ## TBC
 to be continued

--- a/mxml/Portfile
+++ b/mxml/Portfile
@@ -1,0 +1,33 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id$
+
+PortSystem 			  1.0
+
+name            	mxml
+version         	2.10
+
+categories      	net devel
+platforms       	darwin
+license         	Mini-XML License, September 18, 2010
+maintainers     	openmaintainer
+epoch				      0
+
+description     	Tiny XML library.
+long_description  Mini-XML is a small XML parsing library that you can use to read XML \
+					        data files or strings in your application without requiring large \
+					        non-standard libraries. Mini-XML only requires a "make" program and \
+					        an ANSI C compatible compiler - GCC works, as do most \
+					        vendors' ANSI C compilers.
+
+homepage        	https://github.com/michaelrsweet/mxml
+master_sites		  ${homepage}/releases/download/release-${version}
+
+distname        	mxml-${version}
+
+checksums         rmd160  b06a20ed436a7b6845acc66f523985cae8a175eb \
+                  sha256  267ff58b64ddc767170d71dab0c729c06f45e1df9a9b6f75180b564f09767891
+
+patchfiles      	patch-mxml-file.c-issue201.diff \
+					        patch-Makefile.in-DESTDIR.diff
+
+configure.args		--prefix=${prefix}

--- a/mxml/files/patch-Makefile.in-DESTDIR.diff
+++ b/mxml/files/patch-Makefile.in-DESTDIR.diff
@@ -1,0 +1,11 @@
+--- Makefile.in.orig	2014-10-19 19:21:48.000000000 +0200
++++ Makefile.in	2017-08-20 22:24:43.000000000 +0200
+@@ -50,7 +50,7 @@
+ libdir		=	@libdir@
+ mandir		=	@mandir@
+ docdir		=	@docdir@
+-BUILDROOT	=	$(DSTROOT)
++BUILDROOT	=	$(DESTDIR)
+ 
+ 
+ #

--- a/mxml/files/patch-mxml-file.c-issue201.diff
+++ b/mxml/files/patch-mxml-file.c-issue201.diff
@@ -1,0 +1,11 @@
+--- mxml-file.c.orig	2017-08-20 10:13:43.000000000 +0200
++++ mxml-file.c	2017-08-20 10:17:44.000000000 +0200
+@@ -2925,7 +2925,7 @@
+ 	    const char	*newline;	/* Last newline in string */
+ 
+ 
+-	    if ((data = (*global->custom_save_cb)(node)) == NULL)
++	    if ((data = (*global->custom_save_cb)(current)) == NULL)
+ 	      return (-1);
+ 
+ 	    if (mxml_write_string(data, p, putc_cb) < 0)


### PR DESCRIPTION
My test version of a mxml 2.10 port is a newly invented port which installs successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the referred version 25.0 of the forked-daapd media server now. There will be a commit of mxml to become a new official port to the MacPorts project after the testing with forked-daapd is completed.