### PR TITLE
libinotify-kqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
-Please be aware one should use the [port lint](https://guide.macports.org/#using.port.lint) if you modified a Portfile before submitting patches back to MacPorts. The lint action checks if the Portfile conforms to the MacPorts standards specified in Portfile Development.
+Please be aware one should use the [port lint](https://guide.macports.org/#using.port.lint) command if you modified a Portfile before submitting patches back to MacPorts. The lint action checks if the Portfile conforms to the MacPorts standards specified in Portfile Development.
 
 The **macports-test project** is an open-source effort to develop *Portfile* definitions and patch files to simplify the task of compiling and installing open-source software on your Mac. The macports-test project is a user initiative and is neither an official part of the MacPorts project nor a direct part of the open-source software projects referenced. 
 
 Please feel free to download and applicate any experimental ports of macports-test on your own Mac at your own risk. You may find the information of both the [MacPorts Guide section 4.6. Local Portfile Repositories](https://guide.macports.org/#development.local-repositories) and the [MacPorts Guide section 2.2.4. Install Multiple MacPorts Copies](https://guide.macports.org/#installing.macports.source.multiple) quite helpful for such experiments. Please feel free to comment on my macports-test efforts and I would be happy to learn of your findings of such experiments on your own Mac if possible.
 
-The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port IMHO is solely up to the deliberations of the MacPorts team.
+The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port is solely up to the deliberations of the MacPorts team.
 
 - - - 
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,22 @@ Please feel free to download and applicate any experimental ports of macports-te
 
 The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. A final run of the [port lint](https://guide.macports.org/#using.port.lint) command shall ensure the *Portfile* conforms to the [MacPorts development standards](https://guide.macports.org/#development). If such an experimental port will become available as an official port is solely up to the deliberations of the MacPorts team. 
 
+Currently the goal of a **forked-daapd** port is the main driver of my efforts.
+
 - - - 
 
 # Existing Ports Revised 
 
 ## antlr3
-[ANTLRv3](http://www.antlr3.org), ANother Tool for Language Recognition, is the legacy version of a language tool that provides a framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, or C++ actions. 
+[ANTLRv3](http://www.antlr3.org), ANother Tool for Language Recognition, is the legacy version of a language tool that provides a framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, or C++ actions.
 
-By [ANTLR](http://www.antlr.org) is a more recent 4+ version available. IMHO it is unclear if this could add to *forked-daapd*.
+> ANTLR, ANother Tool for Language Recognition, is a language tool that provides a framework for constructing recognizers, interpreters, compilers, and translators from grammatical descriptions containing actions in a variety of target languages. ANTLR provides excellent support for tree construction, tree walking, translation, error recovery, and error reporting.
+
+> Terence Parr is the maniac behind ANTLR and has been working on language tools since 1989.
+
+There is an official [antlr3 3.2 Portfile](https://github.com/macports/macports-ports/blob/master/lang/antlr3/Portfile) available but this does not meet the requirements for the b.m. **forked-daapd** port. Furthermore, I aim for a newly formed *antlr3-no-st3* to avoid conflicts with other ports depending on the antlr3 3.3 port and to better meet the forked-daapd port requirements at the same time.
+
+A more recent 4+ version of [ANTLR](http://www.antlr.org) is available. IMHO it is completlely unclear if this could be added to the forked-daapd port in the future.
 
 ## TBC
 to be continued
@@ -34,18 +42,28 @@ The [forked-daapd project](https://ejurgensen.github.io/forked-daapd/) by @ejurg
 
 >forked-daapd is an iTunes-compatible media server for sharing your media library over the local network with DAAP clients like iTunes. Like iTunes, it can be controlled by Apple Remote (and compatibles) and stream music directly to AirPlay devices. It also supports streaming to RSP clients (Roku devices) and streaming from Spotify.
 
-The [installation instructions for forked-daapd](https://github.com/ejurgensen/forked-daapd/blob/master/INSTALL) is an excellent source of documentation for developers. It contains instructions for installing forked-daapd for Raspbian (Raspberry Pi), Debian/Ubuntu, Fedora, FreeBSD and certainly ___macOS (using MacPorts)___. The following ports all have to be newly formed to establish a *Portfile* for forked-daapd.
+The [installation instructions for forked-daapd](https://github.com/ejurgensen/forked-daapd/blob/master/INSTALL) is an excellent source of documentation for developers. It contains instructions for installing forked-daapd for Raspbian (Raspberry Pi), Debian/Ubuntu, Fedora, FreeBSD and certainly macOS (using MacPorts). The following ports all have to be newly formed to establish a *Portfile* for forked-daapd first.
 
 ### forked-daapd 25.0
-The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
+The version 25.0 of the [forked-daapd media server](https://github.com/ejurgensen/forked-daapd/releases) for macOS (using MacPorts) is yet not available as a MacPorts port and my goal is to make a *forked-daapd v25.0 port* available.
 
+Unfortunately, a recent incompatibility between *gperf* and *gindent* is a main obstacle to get the experimental forked-daapd  port installed. Please refer to the MacPorts Ticket [#54466 assigned defect - gindent @2.2.11: build fails](https://trac.macports.org/ticket/54466) for the background. There seems to be a workaround procedure by downgrading gperf, building gindent, and then upgrading gperf again. However, I will have to follow the more cumbersome procedure as detailed by the [MacPorts Wiki: How to install an older version of a port](https://trac.macports.org/wiki/howto/InstallingOlderPort) after regrettably removing a prior gperf install, I presume.
 
-### antlr3
+Most if not all of the newly formed ports install successfuly on the commandline via the *port install* command on my current macOS Sierra 10.12.6 environment with XCode 8.3.3 and MacPorts 2.4.1 and are awaiting inclusion and testing with this version 25.0 of the forked-daapd media server now. There will be several commits of *Portfiles* which hopefuly become new official ports to the MacPorts project after the testing with forked-daapd is completed.
+
+### antlr3 / antlr3-no-st3
+There is an official antlr3 3.2 Portfile available (see above) but this does not meet the forked-daapd 25.0 requirements.
+
 The ANTLRv3 as a *Java* tool in the 3.5.2 version can downloded as *antlr-3.5.2-complete-no-st3.jar* package from the [ANTLRv3 Downloads](http://www.antlr3.org/download.html) page.
+
+By the command *port install antlr3* my test version of a antlr3 3.5.2 port installs successfuly on the a.m. envrironment. 
+
+The name of this port will be changed to to *antlr3-no-st3* to avoid disambiguation with the existing official antlr3 port.
 
 ### libantlr3c
 The ANTLRv3 C runtime engine for the antlr3 parser in the 3.4 version can be downloded from http://www.antlr3.org/download/C as *libantlr3c-3.4.tar.gz* tarball.
 
+By the command *port install libantlr3c* my test version of a libantlr3c 3.4 port installs successfuly on the a.m. environment. 
 
 ### libinotify-kqueue
 The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue) by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
@@ -57,7 +75,7 @@ The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-
 
 Currently, libinotify-kqueue was not available as a MacPorts port and I am making an experimental *libinotify-kqueue port* available.
 
-My test version of a libinotify-kqueue 20170711 port is a newly formed port which installed successfuly on the commandline via the *port install libinotify-kqueue* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of libinotify-kqueue to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
+By the command *port install libinotify-kqueue* my test version of a libinotify-kqueue 20170711 port installs successfuly on the a.m. environment. 
 
 ### mxml
 The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
@@ -71,7 +89,7 @@ Establishing a new *Portfile* for mxml required two issues to be resolved throug
 1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201) - *patch-mxml-file.c-issue201.diff*
 2. Missing GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html) - *patch-Makefile.in-DESTDIR.diff*
 
-My test version of a mxml 2.10 port is a newly formed port which installed successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
+By the command *port install mxml* my test version of a mxml 2.10 port installs successfuly on the a.m. environment. 
 
 ## TBC
 to be continued

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The macports-test repository
-Testing some ideas on existing ports or newly invented ports for the MacPorts project.
+Developing and testing some ideas on existing ports or by newly formed ports for the MacPorts project.
 
-The **MacPorts Project** is an open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac operating system. Apparently there are many ways one can get involved with MacPorts and peer users, system administrators & developers alike.
+The **MacPorts Project** is an open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac operating system. Like many users I am enjoying the simplicity and availability of open-source software on my Mac by help of MacPorts for some years now. There are many ways one can get involved with MacPorts and peer users, system administrators & developers alike.
 
 - The MacPorts Project official homepage - https://www.macports.org
 - The MacPorts Guide - https://guide.macports.org/
@@ -9,8 +9,12 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 
 The **macports-test project** is an open-source effort to develop *Portfile* definitions and patch files to simplify the task of compiling and installing open-source software on your Mac. The macports-test project is a user initiative and is neither an official part of the MacPorts project nor a direct part of the open-source software projects referenced. 
 
-Please be aware that projects i.e. ports included in this repository may mainly be copies from existing ports and/or open-source software projects and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover by the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
+Please feel free to download and applicate any experimental ports of macports-test on your own Mac at your own risk. You may find the information of both the [MacPorts Guide section 4.6. Local Portfile Repositories](https://guide.macports.org/#development.local-repositories) and the [MacPorts Guide section 2.2.4. Install Multiple MacPorts Copies](https://guide.macports.org/#installing.macports.source.multiple) quite helpful for such experiments. Please feel free to comment on my macports-test efforts and I would be happy to learn of your findings of such experiments on your own Mac if possible.
+
+Both the improved versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port IMHO is solely up to the deliberations of the MacPorts team.
+
 - - - 
+
 # Existing ports addressed 
 ## forked-daapd
 The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
@@ -18,21 +22,40 @@ The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io
 ## TBC
 to be continued
 
-# Newly invented ports
+# My newly formed ports
+## libinotify-kqueue
+The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue) by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
+> The purpose of this library is to provide inotify API on the BSD family of operating systems. The library uses kqueue(2) to monitor the file system activity.
+
+> Copyright (c) 2011-2014 Dmitry Matveev <me@dmitrymatveev.co.uk>
+
+> Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
+
+Currently, libinotify-kqueue is not yet available as a MacPorts port and I am making an experimental *libinotify-kqueue port* available.
+
+My test version of a libinotify-kqueue 20170711 port is a newly formed port which installed successfuly on the commandline via the *port install libinotify-kqueue* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of libinotify-kqueue to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
+
 ## mxml
 The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > Mini-XML is a small XML parsing library that you can use to read XML data files or strings in your application without requiring large non-standard libraries. Mini-XML only requires a "make" program and an ANSI C compatible compiler - GCC works, as do most vendors' ANSI C compilers.
 
 > The Mini-XML library is Copyright 2003-2017 by Michael R Sweet. License terms are described in the file "COPYING".
 
-Currently, mxml is not yet available as a MacPorts port and I am aimed at making a *mxml port* available.
+Currently, mxml is not yet available as a MacPorts port and I am making an experimental *mxml port* available.
 
-Establishing a new *portfile* for mxml required two issues to be resolved through patches:
-1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201)
-2. Missing GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html)
+Establishing a new *Portfile* for mxml required two issues to be resolved through patches:
+1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201) - *patch-Makefile.in-DESTDIR.diff*
+2. Missing GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html) - *patch-Makefile.in-DESTDIR.diff*
 
-My test version of a mxml 2.10 port is a newly invented port which installs successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to become a new official port to the MacPorts project after the testing with forked-daapd is completed.
+My test version of a mxml 2.10 port is a newly formed port which installed successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
 
 ## TBC
 to be continued
+
+- - - 
+
+Copyright 2017 by Zweihorn. License terms are described in the file "LICENSE" of macports-test.
+
+Please be aware that projects i.e. ports included in this repository may mainly be copies from existing ports and/or open-source software projects and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover by the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
+
 - - - 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# The macports-test repository
-Developing and testing some ideas on existing ports or by newly formed ports for the MacPorts project.
+# The MacPorts-Test Repository
+Developing and testing some ideas by revision of existing ports or by newly formed ports for the MacPorts project.
 
 The **MacPorts Project** is an open-source community initiative to design an easy-to-use system for compiling, installing, and upgrading either command-line, X11 or Aqua based open-source software on the Mac operating system. Like many users I am enjoying the simplicity and availability of open-source software on my Mac by help of MacPorts for some years now. There are many ways one can get involved with MacPorts and peer users, system administrators & developers alike.
 
@@ -11,18 +11,18 @@ The **macports-test project** is an open-source effort to develop *Portfile* def
 
 Please feel free to download and applicate any experimental ports of macports-test on your own Mac at your own risk. You may find the information of both the [MacPorts Guide section 4.6. Local Portfile Repositories](https://guide.macports.org/#development.local-repositories) and the [MacPorts Guide section 2.2.4. Install Multiple MacPorts Copies](https://guide.macports.org/#installing.macports.source.multiple) quite helpful for such experiments. Please feel free to comment on my macports-test efforts and I would be happy to learn of your findings of such experiments on your own Mac if possible.
 
-Both the improved versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port IMHO is solely up to the deliberations of the MacPorts team.
+The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port IMHO is solely up to the deliberations of the MacPorts team.
 
 - - - 
 
-# Existing ports addressed 
+# Existing Ports Addressed 
 ## forked-daapd
 The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
 
 ## TBC
 to be continued
 
-# My newly formed ports
+# Newly Formed Ports
 ## libinotify-kqueue
 The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue) by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > The purpose of this library is to provide inotify API on the BSD family of operating systems. The library uses kqueue(2) to monitor the file system activity.
@@ -31,7 +31,7 @@ The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-
 
 > Copyright (c) 2014-2016 Vladimir Kondratiev <wulf@cicgroup.ru>
 
-Currently, libinotify-kqueue is not yet available as a MacPorts port and I am making an experimental *libinotify-kqueue port* available.
+Currently, libinotify-kqueue was not available as a MacPorts port and I am making an experimental *libinotify-kqueue port* available.
 
 My test version of a libinotify-kqueue 20170711 port is a newly formed port which installed successfuly on the commandline via the *port install libinotify-kqueue* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of libinotify-kqueue to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
 
@@ -41,7 +41,7 @@ The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by
 
 > The Mini-XML library is Copyright 2003-2017 by Michael R Sweet. License terms are described in the file "COPYING".
 
-Currently, mxml is not yet available as a MacPorts port and I am making an experimental *mxml port* available.
+Currently, mxml was not available as a MacPorts port and I am making an experimental *mxml port* available.
 
 Establishing a new *Portfile* for mxml required two issues to be resolved through patches:
 1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201) - *patch-Makefile.in-DESTDIR.diff*
@@ -54,8 +54,12 @@ to be continued
 
 - - - 
 
+# Getting Help And Reporting Problems
+The macports-test project page provides access to the [Github issue tracking page](https://github.com/Zweihorn/macports-test/issues). Please be aware that I am not the developer of the open-source software projects referenced by my experimental ports and this project is just a user initiative.
+
+# Legal Stuff
 Copyright 2017 by Zweihorn. License terms are described in the file "LICENSE" of macports-test.
 
-Please be aware that projects i.e. ports included in this repository may mainly be copies from existing ports and/or open-source software projects and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover by the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content included.
+Please be aware that projects i.e. ports included in this repository may mainly be copies from existing ports and/or open-source software projects and the applicable license condition of the original project may apply as appropriate. However, this repository is claiming cover by the [MIT Licence](https://choosealicense.com/licenses/mit/) for all content and the Software included.
 
 - - - 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
+Please be aware one should use the [port lint](https://guide.macports.org/#using.port.lint) if you modified a Portfile before submitting patches back to MacPorts. The lint action checks if the Portfile conforms to the MacPorts standards specified in Portfile Development.
+
 The **macports-test project** is an open-source effort to develop *Portfile* definitions and patch files to simplify the task of compiling and installing open-source software on your Mac. The macports-test project is a user initiative and is neither an official part of the MacPorts project nor a direct part of the open-source software projects referenced. 
 
 Please feel free to download and applicate any experimental ports of macports-test on your own Mac at your own risk. You may find the information of both the [MacPorts Guide section 4.6. Local Portfile Repositories](https://guide.macports.org/#development.local-repositories) and the [MacPorts Guide section 2.2.4. Install Multiple MacPorts Copies](https://guide.macports.org/#installing.macports.source.multiple) quite helpful for such experiments. Please feel free to comment on my macports-test efforts and I would be happy to learn of your findings of such experiments on your own Mac if possible.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By the command *port install antlr3* my test version of a antlr3 3.5.2 port inst
 The name of this port will be changed to to *antlr3-no-st3* to avoid disambiguation with the existing official antlr3 port.
 
 ### libantlr3c
-The ANTLRv3 C runtime engine for the antlr3 parser in the 3.4 version can be downloded from http://www.antlr3.org/download/C as *libantlr3c-3.4.tar.gz* tarball.
+The ANTLRv3 C runtime engine for the antlr3 parser can be downloded from http://www.antlr3.org/download/C as *libantlr3c-3.4.tar.gz*  as tarball in the 3.4 version.
 
 By the command *port install libantlr3c* my test version of a libantlr3c 3.4 port installs successfuly on the a.m. environment. 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ The revised versions of the existing ports addressed and my newly formed ports w
 - - - 
 
 # Existing Ports Addressed 
+
+## antlr3
+
 ## forked-daapd
 The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
 
@@ -23,6 +26,13 @@ The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io
 to be continued
 
 # Newly Formed Ports
+
+## ANTLRv3
+
+### antlr3
+
+### libantlr3c
+
 ## libinotify-kqueue
 The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue) by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > The purpose of this library is to provide inotify API on the BSD family of operating systems. The library uses kqueue(2) to monitor the file system activity.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by
 Currently, mxml was not available as a MacPorts port and I am making an experimental *mxml port* available.
 
 Establishing a new *Portfile* for mxml required two issues to be resolved through patches:
-1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201) - *patch-Makefile.in-DESTDIR.diff*
+1. Bug Report [Problem with MXML_CUSTOM in Version mxml-2.10 #201](https://github.com/michaelrsweet/mxml/issues/201) - *patch-mxml-file.c-issue201.diff*
 2. Missing GNU [DESTDIR: Support for Staged Installs](http://www.gnu.org/prep/standards/html_node/DESTDIR.html) - *patch-Makefile.in-DESTDIR.diff*
 
 My test version of a mxml 2.10 port is a newly formed port which installed successfuly on the commandline via the *port install mxml* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of mxml to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.

--- a/README.md
+++ b/README.md
@@ -7,35 +7,47 @@ The **MacPorts Project** is an open-source community initiative to design an eas
 - The MacPorts Guide - https://guide.macports.org/
 - The MacPorts FAQ - https://trac.macports.org/wiki/FAQ
 
-Please be aware one should use the [port lint](https://guide.macports.org/#using.port.lint) command if you modified a Portfile before submitting patches back to MacPorts. The lint action checks if the Portfile conforms to the MacPorts standards specified in Portfile Development.
+Please be aware one should use the [port lint](https://guide.macports.org/#using.port.lint) command if you modified a Portfile before submitting patches back to MacPorts. The lint action checks if the Portfile conforms to the [MacPorts development standards](https://guide.macports.org/#development).
 
 The **macports-test project** is an open-source effort to develop *Portfile* definitions and patch files to simplify the task of compiling and installing open-source software on your Mac. The macports-test project is a user initiative and is neither an official part of the MacPorts project nor a direct part of the open-source software projects referenced. 
 
 Please feel free to download and applicate any experimental ports of macports-test on your own Mac at your own risk. You may find the information of both the [MacPorts Guide section 4.6. Local Portfile Repositories](https://guide.macports.org/#development.local-repositories) and the [MacPorts Guide section 2.2.4. Install Multiple MacPorts Copies](https://guide.macports.org/#installing.macports.source.multiple) quite helpful for such experiments. Please feel free to comment on my macports-test efforts and I would be happy to learn of your findings of such experiments on your own Mac if possible.
 
-The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. If such experimental port will become available as an official port is solely up to the deliberations of the MacPorts team.
+The revised versions of the existing ports addressed and my newly formed ports will be submitted as a pull request to the MacPorts project after completing basic application tests sufficiently to my best knowledge. A final run of the [port lint](https://guide.macports.org/#using.port.lint) command shall ensure the *Portfile* conforms to the [MacPorts development standards](https://guide.macports.org/#development). If such an experimental port will become available as an official port is solely up to the deliberations of the MacPorts team. 
 
 - - - 
 
-# Existing Ports Addressed 
+# Existing Ports Revised 
 
 ## antlr3
+[ANTLRv3](http://www.antlr3.org), ANother Tool for Language Recognition, is the legacy version of a language tool that provides a framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, or C++ actions. 
 
-## forked-daapd
-The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
+By [ANTLR](http://www.antlr.org) is a more recent 4+ version available. IMHO it is unclear if this could add to *forked-daapd*.
 
 ## TBC
 to be continued
 
 # Newly Formed Ports
 
-## ANTLRv3
+## forked-daapd
+The [forked-daapd project](https://ejurgensen.github.io/forked-daapd/) by @ejurgensen is an open-source Linux/FreeBSD DAAP (iTunes) and MPD media server with support for AirPlay devices (multiroom), Apple Remote (and compatibles), Chromecast, Spotify and internet radio.
+
+>forked-daapd is an iTunes-compatible media server for sharing your media library over the local network with DAAP clients like iTunes. Like iTunes, it can be controlled by Apple Remote (and compatibles) and stream music directly to AirPlay devices. It also supports streaming to RSP clients (Roku devices) and streaming from Spotify.
+
+The [installation instructions for forked-daapd](https://github.com/ejurgensen/forked-daapd/blob/master/INSTALL) is an excellent source of documentation for developers. It contains instructions for installing forked-daapd for Raspbian (Raspberry Pi), Debian/Ubuntu, Fedora, FreeBSD and certainly ___macOS (using MacPorts)___. The following ports all have to be newly formed to establish a *Portfile* for forked-daapd.
+
+### forked-daapd 25.0
+The version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts) is yet not available as a MacPorts port and I am aiming at making a *forked-daapd v25.0 port* available.
+
 
 ### antlr3
+The ANTLRv3 as a *Java* tool in the 3.5.2 version can downloded as *antlr-3.5.2-complete-no-st3.jar* package from the [ANTLRv3 Downloads](http://www.antlr3.org/download.html) page.
 
 ### libantlr3c
+The ANTLRv3 C runtime engine for the antlr3 parser in the 3.4 version can be downloded from http://www.antlr3.org/download/C as *libantlr3c-3.4.tar.gz* tarball.
 
-## libinotify-kqueue
+
+### libinotify-kqueue
 The [libinotify-kqueue library](https://github.com/libinotify-kqueue/libinotify-kqueue) by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > The purpose of this library is to provide inotify API on the BSD family of operating systems. The library uses kqueue(2) to monitor the file system activity.
 
@@ -47,7 +59,7 @@ Currently, libinotify-kqueue was not available as a MacPorts port and I am makin
 
 My test version of a libinotify-kqueue 20170711 port is a newly formed port which installed successfuly on the commandline via the *port install libinotify-kqueue* command on a macOS Sierra 10.12.6 environment with MacPorts 2.4.1 and is awaiting inclusion and testing with the a.m. version 25.0 of the forked-daapd media server now. There will be a commit of libinotify-kqueue to hopefuly become a new official port to the MacPorts project after the testing with forked-daapd is completed.
 
-## mxml
+### mxml
 The tiny XML library [Mini-XML (mxml)](https://github.com/michaelrsweet/mxml) by Michael R Sweet seems to be quite useful and is a required library for the version 25.0 of the [forked-daapd media server](https://ejurgensen.github.io/forked-daapd/) for macOS (using MacPorts).
 > Mini-XML is a small XML parsing library that you can use to read XML data files or strings in your application without requiring large non-standard libraries. Mini-XML only requires a "make" program and an ANSI C compatible compiler - GCC works, as do most vendors' ANSI C compilers.
 

--- a/antlr3/Portfile
+++ b/antlr3/Portfile
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                antlr3
+version             3.5.2
+
+categories          lang java
+platforms           darwin
+license             License
+maintainers         nomaintainer
+
+revision            1
+epoch               0
+
+description         antlr3 is ANother Tool for Language Recognition (legacy version)
+long_description    ANTLRv3, ANother Tool for Language Recognition, is the \
+                    legacy version of a language tool that provides a framework for \
+                    constructing recognizers, compilers, and translators \
+                    from grammatical descriptions containing Java, C#, or \
+                    C++ actions. ANTLR is available in a more recent 4+ version. 
+
+homepage            http://www.antlr3.org
+master_sites        ${homepage}/download
+
+distname            antlr-${version}-complete-no-st3
+
+checksums           rmd160  f870b068ee5fce51029a7491c7b6feaf19dff0c3 \
+                    sha256  46531814ba9739cdf20c6c1789c252d3d95b68932813d79fb8bbfdf8d5840417
+
+extract.suffix      .jar
+extract.only
+
+patchfiles          patch-antlr3-FILE.diff
+
+configure           {}
+
+build		            {}
+
+destroot            {
+    xinstall -d -m 0755 "${destroot}${prefix}/share/java/"
+    xinstall -m 0755 -W ${distpath} ${distname}.jar "${destroot}${prefix}/share/java/"
+    ln ${destroot}${prefix}/share/java/${distname}.jar ${destroot}${prefix}/share/java/antlr3.jar
+    
+    reinplace -W ${worksrcpath} "s|__PREFIX__|${prefix}|g" antlr3
+    reinplace -W ${worksrcpath} "s|__DISTNAME__|${distname}|g" antlr3
+    xinstall -m 0755 -W ${worksrcpath} antlr3 "${destroot}${prefix}/bin/"
+                    }

--- a/antlr3/files/patch-antlr3-FILE.diff
+++ b/antlr3/files/patch-antlr3-FILE.diff
@@ -1,0 +1,7 @@
+--- antlr3.orig	1970-01-01 01:00:00.000000000 +0100
++++ antlr3	2017-08-22 02:04:11.000000000 +0200
+@@ -0,0 +1,4 @@
++#!/bin/sh
++export CLASSPATH
++CLASSPATH=$CLASSPATH:__PREFIX__/share/java/__DISTNAME__.jar:__PREFIX__/share/java
++/usr/bin/java org.antlr.Tool \$*

--- a/libantlr3c/Portfile
+++ b/libantlr3c/Portfile
@@ -1,0 +1,31 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                libantlr3c
+version             3.4
+
+categories          lang java
+platforms           darwin
+license             License
+maintainers         nomaintainer
+
+revision            1
+epoch               0
+
+description         C runtime engine for the antlr3 parser (legacy version)
+long_description    ${description} ANTLRv3, ANother Tool for Language Recognition, is the \
+                    legacy version of a language tool that provides a framework for \
+                    constructing recognizers, compilers, and translators \
+                    from grammatical descriptions containing Java, C#, or \
+                    C++ actions. ANTLR is available in a more recent 4+ version. 
+
+homepage            http://www.antlr3.org
+master_sites        ${homepage}/download/C
+
+distname            libantlr3c-${version}
+
+checksums           rmd160  cbfc13e54f02d87cd82e0c4ca2136fa3fb43dff4 \
+                    sha256  ca914a97f1a2d2f2c8e1fca12d3df65310ff0286d35c48b7ae5f11dcc8b2eb52
+
+configure.args		--prefix=${prefix}

--- a/libinotify-kqueue/Portfile
+++ b/libinotify-kqueue/Portfile
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 # $Id$
 
-PortSystem 			1.0
+PortSystem 		1.0
 
 name            	libinotify-kqueue
 version         	20170711
@@ -10,28 +10,28 @@ categories      	devel
 platforms       	darwin
 license         	MIT
 maintainers     	openmaintainer
-revision			1
-epoch				0
+revision		1
+epoch			0
 
 description     	library with inotify API to monitor file system activities
-long_description    The purpose of this library is to provide inotify API on the \
-					BSD family of operating systems. The library uses kqueue(2) \
-					to monitor the file system activity.
+long_description    	The purpose of this library is to provide inotify API on the \
+			BSD family of operating systems. The library uses kqueue(2) \
+			to monitor the file system activity.
 
 homepage        	https://github.com/libinotify-kqueue/libinotify-kqueue
 master_sites		${homepage}/files/1189065/
 
 distname        	libinotify-${version}
 
-checksums           rmd160  ab5aac65fc6fb9298f32fdd3b81d384d3cad9df9 \
-                    sha256  f71c430f8cd83c4e2d991823f5bbb1a968dbaac442b7447b23d44497cba40695
+checksums           	rmd160  ab5aac65fc6fb9298f32fdd3b81d384d3cad9df9 \
+                    	sha256  f71c430f8cd83c4e2d991823f5bbb1a968dbaac442b7447b23d44497cba40695
 
-depends_build       port:autoconf \
-					port:automake \
-					port:libtool
+depends_build       	port:autoconf \
+			port:automake \
+			port:libtool
 
-use_autoreconf      yes
+use_autoreconf      	yes
 
 pre-configure		{
 	system -W ${worksrcpath} "autoreconf -fvi"
-					}
+			}

--- a/libinotify-kqueue/Portfile
+++ b/libinotify-kqueue/Portfile
@@ -1,0 +1,37 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+# $Id$
+
+PortSystem 			1.0
+
+name            	libinotify-kqueue
+version         	20170711
+
+categories      	devel
+platforms       	darwin
+license         	MIT
+maintainers     	openmaintainer
+revision			1
+epoch				0
+
+description     	library with inotify API to monitor file system activities
+long_description    The purpose of this library is to provide inotify API on the \
+					BSD family of operating systems. The library uses kqueue(2) \
+					to monitor the file system activity.
+
+homepage        	https://github.com/libinotify-kqueue/libinotify-kqueue
+master_sites		${homepage}/files/1189065/
+
+distname        	libinotify-${version}
+
+checksums           rmd160  ab5aac65fc6fb9298f32fdd3b81d384d3cad9df9 \
+                    sha256  f71c430f8cd83c4e2d991823f5bbb1a968dbaac442b7447b23d44497cba40695
+
+depends_build       port:autoconf \
+					port:automake \
+					port:libtool
+
+use_autoreconf      yes
+
+pre-configure		{
+	system -W ${worksrcpath} "autoreconf -fvi"
+					}


### PR DESCRIPTION
The libinotify-kqueue library by Dmitry Matveev and Vladimir Kondratiev seems to be quite useful and (like mxml) is a required library for the version 25.0 of the forked-daapd media server for macOS (using MacPorts).